### PR TITLE
:heavy_plus_sign: add libsignal submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
             core.setFailed('There is a mismatch between configured llvm compiler and clang-tidy version chosen')
 
       - uses: actions/checkout@v5
+        with:
+          submodules: recursive
 
       - name: Setup Cache
         uses: ./.github/actions/setup_cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/libsignal"]
+	path = third_party/libsignal
+	url = https://github.com/signalapp/libsignal.git


### PR DESCRIPTION
- Add official libsignal repository as git submodule at v0.80.0
- Configure CI to recursively checkout submodules
- Provides access to Signal Protocol implementation for encryption