### PR TITLE
:pushpin: resolve libsignal rand version conflicts

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1376,6 +1376,7 @@ name = "signal_bridge"
 version = "0.1.0"
 dependencies = [
  "libsignal-protocol",
+ "rand",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,4 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-# Common dependencies can be defined here and inherited by members
+# Unified versions to align with libsignal dependencies (libsignal uses rand 0.9.2)
+rand = "0.9.2"
+rand_core = "0.9"
+getrandom = "0.3"

--- a/rust/signal_bridge/Cargo.toml
+++ b/rust/signal_bridge/Cargo.toml
@@ -9,3 +9,6 @@ crate-type = ["staticlib"]
 [dependencies]
 # Core libsignal dependencies - using git dependency to avoid linting third-party code
 libsignal-protocol = { git = "https://github.com/signalapp/libsignal.git", tag = "v0.80.0" }
+
+# Use workspace rand version (aligned with libsignal 0.9.2)
+rand = { workspace = true }

--- a/rust/signal_bridge/src/lib.rs
+++ b/rust/signal_bridge/src/lib.rs
@@ -14,4 +14,22 @@ mod tests {
         assert_eq!(protocol_address.name(), "test_device");
         assert_eq!(protocol_address.device_id(), device_id);
     }
+
+    #[test]
+    fn test_identity_key_generation() -> Result<(), SignalProtocolError> {
+        let mut rng = rand::rng();
+        let identity_key_pair = IdentityKeyPair::generate(&mut rng);
+
+        let identity_key = identity_key_pair.identity_key();
+        let public_key_bytes = identity_key.public_key().serialize();
+        assert_eq!(public_key_bytes.len(), 33);
+
+        let private_key_bytes = identity_key_pair.private_key().serialize();
+        assert_eq!(private_key_bytes.len(), 32);
+
+        assert!(!public_key_bytes.iter().all(|&x| x == 0));
+        assert!(!private_key_bytes.iter().all(|&x| x == 0));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
  Align workspace rand dependencies with libsignal requirements:
  - Update workspace to use rand 0.9.2 (matches libsignal)
  - Add test for identity key generation with compatible RNG