### PR TITLE
  ✨ implement libsignal storage traits for SqliteStorage

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1463,6 +1463,7 @@ dependencies = [
 name = "signal_bridge"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "libsignal-protocol",
  "rand",
  "tokio",

--- a/rust/signal_bridge/Cargo.toml
+++ b/rust/signal_bridge/Cargo.toml
@@ -15,3 +15,6 @@ rand = { workspace = true }
 
 # Test dependencies
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros", "sync"] }
+
+# Async trait support
+async-trait = "0.1"

--- a/rust/signal_bridge/src/storage.rs
+++ b/rust/signal_bridge/src/storage.rs
@@ -7,12 +7,15 @@ use libsignal_protocol::*;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use async_trait::async_trait;
 
 pub struct SqliteStorage {
     identity_keys: Arc<Mutex<HashMap<String, IdentityKey>>>,
     pre_keys: Arc<Mutex<HashMap<u32, KeyPair>>>,
     signed_pre_keys: Arc<Mutex<HashMap<u32, SignedPreKeyRecord>>>,
     sessions: Arc<Mutex<HashMap<String, SessionRecord>>>,
+    local_identity_key_pair: Arc<Mutex<Option<IdentityKeyPair>>>,
+    local_registration_id: Arc<Mutex<Option<u32>>>,
 }
 
 impl SqliteStorage {
@@ -22,6 +25,8 @@ impl SqliteStorage {
             pre_keys: Arc::new(Mutex::new(HashMap::new())),
             signed_pre_keys: Arc::new(Mutex::new(HashMap::new())),
             sessions: Arc::new(Mutex::new(HashMap::new())),
+            local_identity_key_pair: Arc::new(Mutex::new(None)),
+            local_registration_id: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -119,6 +124,108 @@ impl SqliteStorage {
     pub async fn session_count(&self) -> usize {
         let store = self.sessions.lock().await;
         store.len()
+    }
+
+    pub async fn set_local_identity_key_pair(&self, identity_key_pair: &IdentityKeyPair) -> Result<(), Box<dyn std::error::Error>> {
+        let mut store = self.local_identity_key_pair.lock().await;
+        *store = Some(*identity_key_pair);
+        Ok(())
+    }
+
+    pub async fn set_local_registration_id(&self, registration_id: u32) -> Result<(), Box<dyn std::error::Error>> {
+        let mut store = self.local_registration_id.lock().await;
+        *store = Some(registration_id);
+        Ok(())
+    }
+}
+
+// Implement libsignal SessionStore trait
+#[async_trait(?Send)]
+impl SessionStore for SqliteStorage {
+    async fn load_session(&self, address: &ProtocolAddress) -> Result<Option<SessionRecord>, SignalProtocolError> {
+        let key = format!("{}:{}", address.name(), u32::from(address.device_id()));
+        let store = self.sessions.lock().await;
+        Ok(store.get(&key).cloned())
+    }
+
+    async fn store_session(
+        &mut self,
+        address: &ProtocolAddress,
+        record: &SessionRecord,
+    ) -> Result<(), SignalProtocolError> {
+        let key = format!("{}:{}", address.name(), u32::from(address.device_id()));
+        let mut store = self.sessions.lock().await;
+        store.insert(key, record.clone());
+        Ok(())
+    }
+}
+
+// Implement libsignal IdentityKeyStore trait
+#[async_trait(?Send)]
+impl IdentityKeyStore for SqliteStorage {
+    async fn get_identity_key_pair(&self) -> Result<IdentityKeyPair, SignalProtocolError> {
+        let store = self.local_identity_key_pair.lock().await;
+        match *store {
+            Some(identity_key_pair) => Ok(identity_key_pair),
+            None => Err(SignalProtocolError::InvalidState("storage", "Local identity key pair not set".to_string())),
+        }
+    }
+
+    async fn get_local_registration_id(&self) -> Result<u32, SignalProtocolError> {
+        let store = self.local_registration_id.lock().await;
+        match *store {
+            Some(registration_id) => Ok(registration_id),
+            None => Err(SignalProtocolError::InvalidState("storage", "Local registration ID not set".to_string())),
+        }
+    }
+
+    async fn save_identity(
+        &mut self,
+        address: &ProtocolAddress,
+        identity_key: &IdentityKey,
+    ) -> Result<IdentityChange, SignalProtocolError> {
+        // Check if this is a new identity or changed identity
+        let existing = self.get_identity(address).await.ok().flatten();
+
+        // Store the identity using our internal method
+        let key = format!("{}:{}", address.name(), u32::from(address.device_id()));
+        let mut store = self.identity_keys.lock().await;
+        store.insert(key, *identity_key);
+
+        match existing {
+            Some(existing_key) if existing_key != *identity_key => {
+                // Identity key changed - return ReplacedExisting
+                Ok(IdentityChange::ReplacedExisting)
+            },
+            Some(_) => {
+                // Identity key unchanged - return NewOrUnchanged
+                Ok(IdentityChange::NewOrUnchanged)
+            },
+            None => {
+                // New identity key - return NewOrUnchanged
+                Ok(IdentityChange::NewOrUnchanged)
+            },
+        }
+    }
+
+    async fn is_trusted_identity(
+        &self,
+        address: &ProtocolAddress,
+        identity_key: &IdentityKey,
+        _direction: Direction,
+    ) -> Result<bool, SignalProtocolError> {
+        let key = format!("{}:{}", address.name(), u32::from(address.device_id()));
+        let store = self.identity_keys.lock().await;
+        match store.get(&key) {
+            Some(stored_key) => Ok(*stored_key == *identity_key),
+            None => Ok(true), // Trust on first use
+        }
+    }
+
+    async fn get_identity(&self, address: &ProtocolAddress) -> Result<Option<IdentityKey>, SignalProtocolError> {
+        let key = format!("{}:{}", address.name(), u32::from(address.device_id()));
+        let store = self.identity_keys.lock().await;
+        Ok(store.get(&key).copied())
     }
 }
 
@@ -303,6 +410,86 @@ mod tests {
         let retrieved = storage.load_session(&address).await?;
 
         assert!(retrieved.is_some());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_storage_implements_libsignal_session_store() -> Result<(), Box<dyn std::error::Error>> {
+        let mut storage = SqliteStorage::new(":memory:").await?;
+
+        // Test that our storage can be used as a libsignal SessionStore
+        let address = ProtocolAddress::new("test_user".to_string(), DeviceId::new(1)?);
+        let session_record = SessionRecord::new_fresh();
+
+        // This should work with libsignal SessionStore trait methods
+        let result = <SqliteStorage as SessionStore>::store_session(
+            &mut storage,
+            &address,
+            &session_record,
+        ).await;
+        assert!(result.is_ok());
+
+        let loaded = <SqliteStorage as SessionStore>::load_session(
+            &storage,
+            &address,
+        ).await?;
+        assert!(loaded.is_some());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_storage_implements_libsignal_identity_key_store() -> Result<(), Box<dyn std::error::Error>> {
+        let mut storage = SqliteStorage::new(":memory:").await?;
+
+        // Test that our storage can be used as a libsignal IdentityKeyStore
+        let address = ProtocolAddress::new("test_user".to_string(), DeviceId::new(1)?);
+        let mut rng = rand::rng();
+        let identity_key_pair = IdentityKeyPair::generate(&mut rng);
+
+        // This should work with libsignal IdentityKeyStore trait methods
+        let result = <SqliteStorage as IdentityKeyStore>::save_identity(
+            &mut storage,
+            &address,
+            identity_key_pair.identity_key(),
+        ).await;
+        assert!(result.is_ok());
+
+        let retrieved = <SqliteStorage as IdentityKeyStore>::get_identity(
+            &storage,
+            &address,
+        ).await?;
+        assert!(retrieved.is_some());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_local_identity_and_registration_storage() -> Result<(), Box<dyn std::error::Error>> {
+        let storage = SqliteStorage::new(":memory:").await?;
+
+        // Test that local identity methods require setup first
+        let identity_result = <SqliteStorage as IdentityKeyStore>::get_identity_key_pair(&storage).await;
+        assert!(identity_result.is_err());
+
+        let registration_result = <SqliteStorage as IdentityKeyStore>::get_local_registration_id(&storage).await;
+        assert!(registration_result.is_err());
+
+        // Set up local identity and registration ID
+        let mut rng = rand::rng();
+        let identity_key_pair = IdentityKeyPair::generate(&mut rng);
+        let registration_id = 54321;
+
+        storage.set_local_identity_key_pair(&identity_key_pair).await?;
+        storage.set_local_registration_id(registration_id).await?;
+
+        // Now the trait methods should work
+        let retrieved_identity = <SqliteStorage as IdentityKeyStore>::get_identity_key_pair(&storage).await?;
+        assert_eq!(retrieved_identity.identity_key().serialize(), identity_key_pair.identity_key().serialize());
+
+        let retrieved_registration = <SqliteStorage as IdentityKeyStore>::get_local_registration_id(&storage).await?;
+        assert_eq!(retrieved_registration, registration_id);
 
         Ok(())
     }


### PR DESCRIPTION
    - Add SessionStore trait implementation with session load/store methods
    - Add IdentityKeyStore trait implementation with identity management
    - Implement local identity key pair and registration ID storage
    - Add proper IdentityChange enum handling (NewOrUnchanged, ReplacedExisting)
    - Add async-trait dependency for trait implementations