### PR TITLE
✨ implement structured error types for CXX bridge compatibility

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
  "rand",
  "sha2",
  "subtle",
- "thiserror",
+ "thiserror 2.0.16",
  "uuid",
  "x25519-dalek",
 ]
@@ -1008,7 +1008,7 @@ dependencies = [
  "signal-crypto",
  "spqr",
  "subtle",
- "thiserror",
+ "thiserror 2.0.16",
  "uuid",
  "zerocopy",
 ]
@@ -1589,7 +1589,7 @@ dependencies = [
  "sha1",
  "sha2",
  "subtle",
- "thiserror",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1602,6 +1602,7 @@ dependencies = [
  "rand",
  "rusqlite",
  "serde",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -1644,7 +1645,7 @@ dependencies = [
  "rand_core 0.9.3",
  "sha2",
  "sorted-vec",
- "thiserror",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1704,11 +1705,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/rust/signal_bridge/Cargo.toml
+++ b/rust/signal_bridge/Cargo.toml
@@ -25,3 +25,6 @@ rusqlite = { version = "0.32", features = ["bundled", "chrono"] }
 # Serialization support
 bincode = "1.3"
 serde = { version = "1.0", features = ["derive"] }
+
+# Error handling
+thiserror = "1.0"


### PR DESCRIPTION
  Replace Box<dyn std::error::Error> with SignalBridgeError enum to enable
  C++ integration via CXX bridge.