### PR TITLE
:sparkles: add key sharing across nostr and contact list

### DIFF
--- a/include/radix_relay/events/nostr_events.hpp
+++ b/include/radix_relay/events/nostr_events.hpp
@@ -6,6 +6,11 @@ namespace radix_relay::nostr::events {
 
 namespace incoming {
 
+  struct bundle_announcement : protocol::event_data
+  {
+    explicit bundle_announcement(const protocol::event_data &event) : protocol::event_data(event) {}
+  };
+
   struct identity_announcement : protocol::event_data
   {
     explicit identity_announcement(const protocol::event_data &event) : protocol::event_data(event) {}
@@ -50,6 +55,11 @@ namespace incoming {
 }// namespace incoming
 
 namespace outgoing {
+
+  struct bundle_announcement : protocol::event_data
+  {
+    explicit bundle_announcement(const protocol::event_data &event) : protocol::event_data(event) {}
+  };
 
   struct identity_announcement : protocol::event_data
   {

--- a/include/radix_relay/nostr_handler.hpp
+++ b/include/radix_relay/nostr_handler.hpp
@@ -31,6 +31,9 @@ private:
     }
 
     switch (kind.value()) {
+    case protocol::kind::bundle_announcement:
+      handler_.handle(events::incoming::bundle_announcement{ event });
+      break;
     case protocol::kind::identity_announcement:
       handler_.handle(events::incoming::identity_announcement{ event });
       break;
@@ -43,6 +46,7 @@ private:
     case protocol::kind::node_status:
       handler_.handle(events::incoming::node_status{ event });
       break;
+    case protocol::kind::parameterized_replaceable_start:
     case protocol::kind::profile_metadata:
     case protocol::kind::text_note:
     case protocol::kind::recommend_relay:

--- a/include/radix_relay/nostr_protocol.hpp
+++ b/include/radix_relay/nostr_protocol.hpp
@@ -23,6 +23,10 @@ enum class kind : std::uint32_t {
   encrypted_dm = 4,
   reaction = 7,
 
+  // Standard Nostr parameterized replaceable events
+  parameterized_replaceable_start = 30000,
+  bundle_announcement = 30078,
+
   // Radix Relay custom kinds (40001-40099 reserved)
   encrypted_message = 40001,
   identity_announcement = 40002,
@@ -137,6 +141,21 @@ struct event_data
     };
   }
 
+  static auto create_bundle_announcement(const std::string &sender_pubkey,
+    std::uint64_t timestamp,
+    const std::string &bundle_hex) -> event_data
+  {
+    return {
+      .id = "",// Will be computed when signing
+      .pubkey = sender_pubkey,
+      .created_at = timestamp,
+      .kind = static_cast<std::uint32_t>(kind::bundle_announcement),
+      .tags = { { "radix_version", std::string{ radix_relay::cmake::project_version } } },
+      .content = bundle_hex,
+      .sig = ""// Will be computed when signing
+    };
+  }
+
   static auto create_encrypted_message(std::uint64_t timestamp,
     const std::string &recipient_pubkey,
     const std::string &encrypted_payload,
@@ -178,6 +197,7 @@ struct event_data
     case static_cast<std::uint32_t>(kind::identity_announcement):
     case static_cast<std::uint32_t>(kind::session_request):
     case static_cast<std::uint32_t>(kind::node_status):
+    case static_cast<std::uint32_t>(kind::bundle_announcement):
       return true;
     case static_cast<std::uint32_t>(kind::profile_metadata):
     case static_cast<std::uint32_t>(kind::text_note):
@@ -205,6 +225,8 @@ struct event_data
       return kind::encrypted_dm;
     case 7:
       return kind::reaction;
+    case 30078:
+      return kind::bundle_announcement;
     case 40001:
       return kind::encrypted_message;
     case 40002:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2381,6 +2381,7 @@ name = "signal_bridge"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "bincode",
  "cxx",
  "cxx-build",

--- a/rust/signal_bridge/Cargo.toml
+++ b/rust/signal_bridge/Cargo.toml
@@ -47,5 +47,8 @@ serde_json = "1.0"
 # Hex encoding/decoding
 hex = "0.4"
 
+# Base64 encoding/decoding
+base64 = "0.22"
+
 [build-dependencies]
 cxx-build = "1.0"

--- a/test/test_doubles/test_double_nostr_handler.hpp
+++ b/test/test_doubles/test_double_nostr_handler.hpp
@@ -10,6 +10,7 @@ namespace radix_relay_test {
 class TestDoubleNostrHandler
 {
 public:
+  mutable std::vector<radix_relay::nostr::protocol::event_data> bundle_events;
   mutable std::vector<radix_relay::nostr::protocol::event_data> identity_events;
   mutable std::vector<radix_relay::nostr::protocol::event_data> encrypted_events;
   mutable std::vector<radix_relay::nostr::protocol::event_data> session_events;
@@ -18,11 +19,17 @@ public:
   mutable std::vector<radix_relay::nostr::protocol::ok> ok_msgs;
   mutable std::vector<radix_relay::nostr::protocol::eose> eose_msgs;
   mutable std::vector<std::string> unknown_msgs;
+  mutable std::vector<radix_relay::nostr::protocol::event_data> outgoing_bundle_events;
   mutable std::vector<radix_relay::nostr::protocol::event_data> outgoing_identity_events;
   mutable std::vector<radix_relay::nostr::protocol::event_data> outgoing_encrypted_events;
   mutable std::vector<radix_relay::nostr::protocol::event_data> outgoing_session_events;
   mutable std::vector<radix_relay::nostr::events::outgoing::plaintext_message> plaintext_messages;
   mutable std::vector<radix_relay::nostr::events::outgoing::subscription_request> subscription_requests;
+
+  auto handle(const radix_relay::nostr::events::incoming::bundle_announcement &event) const -> void
+  {
+    bundle_events.push_back(event);
+  }
 
   auto handle(const radix_relay::nostr::events::incoming::identity_announcement &event) const -> void
   {
@@ -56,6 +63,13 @@ public:
   auto handle(const radix_relay::nostr::events::incoming::unknown_protocol &event) const -> void
   {
     unknown_msgs.push_back(event.message);
+  }
+
+  auto handle(const radix_relay::nostr::events::outgoing::bundle_announcement &event,
+    const std::function<void(const std::string &)> &track_fn = nullptr) const -> void
+  {
+    outgoing_bundle_events.push_back(event);
+    if (track_fn) { track_fn(event.id); }
   }
 
   auto handle(const radix_relay::nostr::events::outgoing::identity_announcement &event,


### PR DESCRIPTION
- key bundles can be shared via nostr
- contact list functionality added to alias sessions
- RDX acts as the primary identifier for sessions