### PR TITLE
:sparkles: update signal bridge lifecycle mgmt

### DIFF
--- a/fuzz_test/fuzz_tester.cpp
+++ b/fuzz_test/fuzz_tester.cpp
@@ -4,6 +4,7 @@
 #include <radix_relay/cli.hpp>
 #include <radix_relay/node_identity.hpp>
 #include <radix_relay/platform/env_utils.hpp>
+#include <radix_relay/signal_bridge.hpp>
 #include <radix_relay/standard_event_handler.hpp>
 #include <string>
 #include <utility>
@@ -13,18 +14,20 @@
 // NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" auto LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) -> int
 {
+  using bridge_t = radix_relay::signal::bridge;
+
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   const std::string input(reinterpret_cast<const char *>(Data), Size);
 
   auto db_path =
     (std::filesystem::path(radix_relay::platform::get_temp_directory()) / "fuzz_signal_bridge.db").string();
-  auto bridge = radix_relay::new_signal_bridge(db_path.c_str());
-  auto command_handler = std::make_shared<radix_relay::standard_event_handler_t::command_handler_t>(std::move(bridge));
-  auto event_handler = std::make_shared<radix_relay::standard_event_handler_t>(command_handler);
+  auto bridge = std::make_shared<bridge_t>(db_path);
+
+  auto command_handler = std::make_shared<radix_relay::command_handler<bridge_t>>(bridge);
+  auto event_handler = std::make_shared<radix_relay::standard_event_handler_t<bridge_t>>(command_handler);
   radix_relay::interactive_cli cli("fuzz-node", "hybrid", event_handler);
 
-  using cli_type_t = decltype(cli);
-  std::ignore = cli_type_t::should_quit(input);
+  std::ignore = cli.should_quit(input);
   std::ignore = cli.handle_command(input);
 
   // Cleanup: Remove the temporary database file

--- a/include/radix_relay/concepts/signal_bridge.hpp
+++ b/include/radix_relay/concepts/signal_bridge.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+#include <radix_relay/signal_types.hpp>
+#include <string>
+#include <vector>
+
+namespace radix_relay::concepts {
+
+template<typename T>
+concept signal_bridge = requires(T bridge,
+  const std::string &rdx,
+  const std::string &alias,
+  const std::string &bundle,
+  const std::string &version,
+  const std::string &content,
+  const std::vector<uint8_t> &bytes,
+  uint32_t timestamp) {
+  // Identity and session management
+  { bridge.get_node_fingerprint() } -> std::convertible_to<std::string>;
+  { bridge.list_contacts() } -> std::convertible_to<std::vector<radix_relay::signal::contact_info>>;
+
+  // Message encryption/decryption
+  { bridge.encrypt_message(rdx, bytes) } -> std::convertible_to<std::vector<uint8_t>>;
+  { bridge.decrypt_message(rdx, bytes) } -> std::convertible_to<std::vector<uint8_t>>;
+
+  // Session establishment
+  { bridge.add_contact_and_establish_session_from_base64(bundle, alias) } -> std::convertible_to<std::string>;
+
+  // Bundle generation
+  { bridge.generate_prekey_bundle_announcement(version) } -> std::convertible_to<std::string>;
+
+  // Contact management
+  { bridge.assign_contact_alias(rdx, alias) } -> std::same_as<void>;
+  { bridge.lookup_contact(alias) } -> std::convertible_to<radix_relay::signal::contact_info>;
+
+  // Nostr signing
+  { bridge.create_and_sign_encrypted_message(rdx, content, timestamp, version) } -> std::convertible_to<std::string>;
+  { bridge.sign_nostr_event(content) } -> std::convertible_to<std::string>;
+};
+
+}// namespace radix_relay::concepts

--- a/include/radix_relay/signal_bridge.hpp
+++ b/include/radix_relay/signal_bridge.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <algorithm>
+#include <filesystem>
+#include <iterator>
+#include <radix_relay/concepts/signal_bridge.hpp>
+#include <radix_relay/node_identity.hpp>
+#include <radix_relay/signal_types.hpp>
+#include <rust/cxx.h>
+#include <signal_bridge_cxx/lib.h>
+#include <string>
+#include <vector>
+
+namespace radix_relay::signal {
+
+class bridge
+{
+public:
+  explicit bridge(const std::filesystem::path &bridge_db)
+    : bridge_(radix_relay::new_signal_bridge(bridge_db.string().c_str()))
+  {}
+  explicit bridge(rust::Box<SignalBridge> signal_bridge) : bridge_(std::move(signal_bridge)) {}
+
+  bridge(const bridge &) = delete;
+  auto operator=(const bridge &) -> bridge & = delete;
+  bridge(bridge &&) = default;
+  auto operator=(bridge &&) -> bridge & = default;
+  ~bridge() = default;
+
+  auto get_node_fingerprint() const -> std::string { return radix_relay::get_node_fingerprint(*bridge_); }
+
+  auto list_contacts() const -> std::vector<signal::contact_info>
+  {
+    auto rust_contacts = radix_relay::list_contacts(*bridge_);
+    std::vector<signal::contact_info> result;
+    result.reserve(rust_contacts.size());
+
+    std::ranges::transform(rust_contacts, std::back_inserter(result), [](const auto &contact) {
+      return signal::contact_info{
+        .rdx_fingerprint = std::string(contact.rdx_fingerprint),
+        .nostr_pubkey = std::string(contact.nostr_pubkey),
+        .user_alias = std::string(contact.user_alias),
+        .has_active_session = contact.has_active_session,
+      };
+    });
+
+    return result;
+  }
+
+  auto encrypt_message(const std::string &rdx, const std::vector<uint8_t> &bytes) const -> std::vector<uint8_t>
+  {
+    auto encrypted =
+      radix_relay::encrypt_message(*bridge_, rdx.c_str(), rust::Slice<const uint8_t>{ bytes.data(), bytes.size() });
+    return { encrypted.begin(), encrypted.end() };
+  }
+
+  auto decrypt_message(const std::string &rdx, const std::vector<uint8_t> &bytes) const -> std::vector<uint8_t>
+  {
+    auto decrypted =
+      radix_relay::decrypt_message(*bridge_, rdx.c_str(), rust::Slice<const uint8_t>{ bytes.data(), bytes.size() });
+    return { decrypted.begin(), decrypted.end() };
+  }
+
+  auto add_contact_and_establish_session_from_base64(const std::string &bundle, const std::string &alias) const
+    -> std::string
+  {
+    auto peer_rdx = radix_relay::add_contact_and_establish_session_from_base64(*bridge_, bundle.c_str(), alias.c_str());
+    return std::string(peer_rdx);
+  }
+
+  auto generate_prekey_bundle_announcement(const std::string &version) const -> std::string
+  {
+    auto bundle_json = radix_relay::generate_prekey_bundle_announcement(*bridge_, version.c_str());
+    return std::string(bundle_json);
+  }
+
+  auto assign_contact_alias(const std::string &rdx, const std::string &alias) const -> void
+  {
+    radix_relay::assign_contact_alias(*bridge_, rdx.c_str(), alias.c_str());
+  }
+
+  auto create_and_sign_encrypted_message(const std::string &rdx,
+    const std::string &content,
+    uint32_t timestamp,
+    const std::string &version) const -> std::string
+  {
+    auto signed_event = radix_relay::create_and_sign_encrypted_message(
+      *bridge_, rdx.c_str(), content.c_str(), timestamp, version.c_str());
+    return std::string(signed_event);
+  }
+
+  auto lookup_contact(const std::string &alias) const -> signal::contact_info
+  {
+    auto rust_contact = radix_relay::lookup_contact(*bridge_, alias.c_str());
+    return {
+      .rdx_fingerprint = std::string(rust_contact.rdx_fingerprint),
+      .nostr_pubkey = std::string(rust_contact.nostr_pubkey),
+      .user_alias = std::string(rust_contact.user_alias),
+      .has_active_session = rust_contact.has_active_session,
+    };
+  }
+
+  auto sign_nostr_event(const std::string &event_json) const -> std::string
+  {
+    auto signed_event = radix_relay::sign_nostr_event(*bridge_, event_json.c_str());
+    return std::string(signed_event);
+  }
+
+  auto get_rust_bridge() -> SignalBridge & { return *bridge_; }
+
+private:
+  mutable rust::Box<SignalBridge> bridge_;
+};
+
+static_assert(concepts::signal_bridge<bridge>);
+
+}// namespace radix_relay::signal

--- a/include/radix_relay/signal_types.hpp
+++ b/include/radix_relay/signal_types.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace radix_relay::signal {
+
+struct contact_info
+{
+  std::string rdx_fingerprint;
+  std::string nostr_pubkey;
+  std::string user_alias;
+  bool has_active_session;
+};
+
+}// namespace radix_relay::signal

--- a/include/radix_relay/standard_event_handler.hpp
+++ b/include/radix_relay/standard_event_handler.hpp
@@ -2,12 +2,11 @@
 
 #include <radix_relay/command_handler.hpp>
 #include <radix_relay/concepts/event_handler.hpp>
+#include <radix_relay/concepts/signal_bridge.hpp>
 #include <radix_relay/event_handler.hpp>
 
 namespace radix_relay {
 
-using standard_event_handler_t = event_handler<command_handler>;
-
-static_assert(concepts::event_handler<standard_event_handler_t>);
+template<concepts::signal_bridge Bridge> using standard_event_handler_t = event_handler<command_handler<Bridge>>;
 
 }// namespace radix_relay

--- a/src/radix_relay/main.cpp
+++ b/src/radix_relay/main.cpp
@@ -1,4 +1,5 @@
 #include <radix_relay/cli.hpp>
+#include <radix_relay/signal_bridge.hpp>
 #include <radix_relay/standard_event_handler.hpp>
 #include <spdlog/spdlog.h>
 
@@ -11,22 +12,25 @@
 // NOLINTNEXTLINE(bugprone-exception-escape)
 auto main(int argc, char **argv) -> int
 {
+  using bridge_t = radix_relay::signal::bridge;
+
   auto args = radix_relay::parse_cli_args(argc, argv);
 
   if (not radix_relay::validate_cli_args(args)) { return 1; }
 
   radix_relay::configure_logging(args);
 
-  auto bridge = radix_relay::new_signal_bridge(args.identity_path.c_str());
-  auto node_fingerprint = radix_relay::get_node_fingerprint(*bridge);
-  auto command_handler = std::make_shared<radix_relay::standard_event_handler_t::command_handler_t>(std::move(bridge));
+  auto bridge = std::make_shared<bridge_t>(args.identity_path);
+  auto node_fingerprint = bridge->get_node_fingerprint();
+
+  auto command_handler = std::make_shared<radix_relay::command_handler<bridge_t>>(bridge);
 
   if (radix_relay::execute_cli_command(args, command_handler)) { return 0; }
   radix_relay::print_app_banner(
     { .node_fingerprint = node_fingerprint, .mode = args.mode, .identity_path = args.identity_path });
   radix_relay::print_available_commands();
 
-  auto event_handler = std::make_shared<radix_relay::standard_event_handler_t>(command_handler);
+  auto event_handler = std::make_shared<radix_relay::standard_event_handler_t<bridge_t>>(command_handler);
   radix_relay::interactive_cli cli(node_fingerprint, args.mode, event_handler);
   cli.run();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,8 @@ add_catch_test(NAME nostr_message_handler_tests SOURCES nostr_message_handler_te
 add_catch_test(NAME session_orchestrator_tests SOURCES session_orchestrator_tests.cpp LIBS signal_bridge_cxx Boost::asio nlohmann_json::nlohmann_json fmt::fmt)
 add_catch_test(NAME nostr_request_tracker_tests SOURCES nostr_request_tracker_tests.cpp LIBS nlohmann_json::nlohmann_json)
 add_catch_test(NAME nostr_signing_tests SOURCES nostr_signing_tests.cpp LIBS nlohmann_json::nlohmann_json signal_bridge_cxx)
+add_catch_test(NAME raw_signal_bridge_tests SOURCES raw_signal_bridge_tests.cpp LIBS signal_bridge_cxx PREFIX signal)
+add_catch_test(NAME signal_bridge_tests SOURCES signal_bridge_tests.cpp LIBS signal_bridge_cxx PREFIX signal)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
   add_custom_command(
@@ -82,11 +84,7 @@ if(WIN32 AND BUILD_SHARED_LIBS)
     COMMAND_EXPAND_LISTS)
 endif()
 
-if(TARGET signal_bridge_cxx)
-  add_catch_test(NAME signal_bridge_tests SOURCES signal_bridge_tests.cpp LIBS signal_bridge_cxx PREFIX signal)
-
-  # Disable static analysis for generated CXX bridge code
-  set_target_properties(signal_bridge_tests PROPERTIES
-    CXX_CLANG_TIDY ""
-    CXX_CPPCHECK "")
-endif()
+# Disable static analysis for generated CXX bridge code
+set_target_properties(signal_bridge_tests PROPERTIES
+  CXX_CLANG_TIDY ""
+  CXX_CPPCHECK "")

--- a/test/cli_utils_tests.cpp
+++ b/test/cli_utils_tests.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdio>
 #include <filesystem>
+#include <radix_relay/signal_bridge.hpp>
 #include <sstream>
 #include <tuple>
 #include <vector>
@@ -99,76 +100,75 @@ TEST_CASE("validate_cli_args validates send command", "[cli_utils][cli_parser]")
 
 TEST_CASE("execute_cli_command handles version flag", "[cli_utils][app_init]")
 {
-  auto bridge = radix_relay::new_signal_bridge(
-    (std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_version.db").string());
-  auto command_handler = std::make_shared<radix_relay::standard_event_handler_t::command_handler_t>(std::move(bridge));
-  radix_relay::cli_args args;
-  args.show_version = true;
+  const auto db_path =
+    std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_version.db";
+  {
+    auto bridge_wrapper = std::make_shared<radix_relay::signal::bridge>(db_path);
+    auto command_handler = std::make_shared<radix_relay::command_handler<radix_relay::signal::bridge>>(bridge_wrapper);
+    radix_relay::cli_args args;
+    args.show_version = true;
 
-  REQUIRE(radix_relay::execute_cli_command(args, command_handler) == true);
-  std::ignore =
-    std::remove((std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_version.db")
-        .string()
-        .c_str());
+    REQUIRE(radix_relay::execute_cli_command(args, command_handler) == true);
+  }
+  std::ignore = std::filesystem::remove(db_path);
 }
 
 TEST_CASE("execute_cli_command handles send command", "[cli_utils][app_init]")
 {
-  auto bridge = radix_relay::new_signal_bridge(
-    (std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_send.db").string());
-  auto command_handler = std::make_shared<radix_relay::standard_event_handler_t::command_handler_t>(std::move(bridge));
-  radix_relay::cli_args args;
-  args.send_parsed = true;
-  args.send_recipient = "alice";
-  args.send_message = "test message";
+  const auto db_path = std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_send.db";
+  {
+    auto bridge_wrapper = std::make_shared<radix_relay::signal::bridge>(db_path);
+    auto command_handler = std::make_shared<radix_relay::command_handler<radix_relay::signal::bridge>>(bridge_wrapper);
+    radix_relay::cli_args args;
+    args.send_parsed = true;
+    args.send_recipient = "alice";
+    args.send_message = "test message";
 
-  REQUIRE(radix_relay::execute_cli_command(args, command_handler) == true);
-  std::ignore = std::remove(
-    (std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_send.db").string().c_str());
+    REQUIRE(radix_relay::execute_cli_command(args, command_handler) == true);
+  }
+  std::ignore = std::filesystem::remove(db_path);
 }
 
 TEST_CASE("execute_cli_command handles peers command", "[cli_utils][app_init]")
 {
-  auto bridge = radix_relay::new_signal_bridge(
-    (std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_peers.db").string());
-  auto command_handler = std::make_shared<radix_relay::standard_event_handler_t::command_handler_t>(std::move(bridge));
-  radix_relay::cli_args args;
-  args.peers_parsed = true;
+  const auto db_path = std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_peers.db";
+  {
+    auto bridge_wrapper = std::make_shared<radix_relay::signal::bridge>(db_path);
+    auto command_handler = std::make_shared<radix_relay::command_handler<radix_relay::signal::bridge>>(bridge_wrapper);
+    radix_relay::cli_args args;
+    args.peers_parsed = true;
 
-  REQUIRE(radix_relay::execute_cli_command(args, command_handler) == true);
-  std::ignore =
-    std::remove((std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_peers.db")
-        .string()
-        .c_str());
+    REQUIRE(radix_relay::execute_cli_command(args, command_handler) == true);
+  }
+  std::ignore = std::filesystem::remove(db_path);
 }
 
 TEST_CASE("execute_cli_command handles status command", "[cli_utils][app_init]")
 {
-  auto bridge = radix_relay::new_signal_bridge(
-    (std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_status.db").string());
-  auto command_handler = std::make_shared<radix_relay::standard_event_handler_t::command_handler_t>(std::move(bridge));
-  radix_relay::cli_args args;
-  args.status_parsed = true;
+  const auto db_path =
+    std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_status.db";
+  {
+    auto bridge_wrapper = std::make_shared<radix_relay::signal::bridge>(db_path);
+    auto command_handler = std::make_shared<radix_relay::command_handler<radix_relay::signal::bridge>>(bridge_wrapper);
+    radix_relay::cli_args args;
+    args.status_parsed = true;
 
-  REQUIRE(radix_relay::execute_cli_command(args, command_handler) == true);
-  std::ignore =
-    std::remove((std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_status.db")
-        .string()
-        .c_str());
+    REQUIRE(radix_relay::execute_cli_command(args, command_handler) == true);
+  }
+  std::ignore = std::filesystem::remove(db_path);
 }
 
 TEST_CASE("execute_cli_command returns false for no commands", "[cli_utils][app_init]")
 {
-  auto bridge = radix_relay::new_signal_bridge(
-    (std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_false.db").string());
-  auto command_handler = std::make_shared<radix_relay::standard_event_handler_t::command_handler_t>(std::move(bridge));
-  const radix_relay::cli_args args;
+  const auto db_path = std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_false.db";
+  {
+    auto bridge_wrapper = std::make_shared<radix_relay::signal::bridge>(db_path);
+    auto command_handler = std::make_shared<radix_relay::command_handler<radix_relay::signal::bridge>>(bridge_wrapper);
+    const radix_relay::cli_args args;
 
-  REQUIRE(radix_relay::execute_cli_command(args, command_handler) == false);
-  std::ignore =
-    std::remove((std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_execute_cli_false.db")
-        .string()
-        .c_str());
+    REQUIRE(radix_relay::execute_cli_command(args, command_handler) == false);
+  }
+  std::ignore = std::filesystem::remove(db_path);
 }
 
 TEST_CASE("configure_logging sets debug level when verbose", "[cli_utils][app_init]")
@@ -190,19 +190,17 @@ TEST_CASE("configure_logging sets debug level when verbose", "[cli_utils][app_in
 
 TEST_CASE("get_node_fingerprint returns valid fingerprint", "[cli_utils][app_init]")
 {
-  auto bridge = radix_relay::new_signal_bridge(
-    (std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_cli_utils_fingerprint.db").string());
-  auto fingerprint = radix_relay::get_node_fingerprint(*bridge);
+  const auto db_path =
+    std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_cli_utils_fingerprint.db";
+  {
+    auto bridge_wrapper = std::make_shared<radix_relay::signal::bridge>(db_path);
+    auto fingerprint = bridge_wrapper->get_node_fingerprint();
 
-  REQUIRE_FALSE(fingerprint.empty());
-  REQUIRE(fingerprint.starts_with("RDX:"));
-  REQUIRE(fingerprint.length() == 68);
-
-  // Clean up test database
-  std::ignore =
-    std::remove((std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_cli_utils_fingerprint.db")
-        .string()
-        .c_str());
+    REQUIRE_FALSE(fingerprint.empty());
+    REQUIRE(fingerprint.starts_with("RDX:"));
+    REQUIRE(fingerprint.length() == 68);
+  }
+  std::ignore = std::filesystem::remove(db_path);
 }
 
 TEST_CASE("app_state construction", "[cli_utils][app_init]")

--- a/test/node_identity_tests.cpp
+++ b/test/node_identity_tests.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <radix_relay/node_identity.hpp>
 #include <radix_relay/platform/env_utils.hpp>
+#include <radix_relay/signal_bridge.hpp>
 #include <tuple>
 
 TEST_CASE("Node Identity Functions", "[node_identity]")
@@ -19,20 +20,20 @@ TEST_CASE("Node Identity Functions", "[node_identity]")
 
   SECTION("get_node_fingerprint returns deterministic fingerprint")
   {
-    auto bridge = radix_relay::new_signal_bridge(
-      (std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_node_identity_fingerprint.db")
-        .string());
+    {
+      auto bridge = std::make_shared<radix_relay::signal::bridge>(
+        std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_node_identity_fingerprint.db");
 
-    auto fingerprint1 = radix_relay::get_node_fingerprint(*bridge);
-    auto fingerprint2 = radix_relay::get_node_fingerprint(*bridge);
+      // cppcheck-suppress duplicateAssignExpression
+      auto fingerprint1 = bridge->get_node_fingerprint();
+      auto fingerprint2 = bridge->get_node_fingerprint();
 
-    REQUIRE(fingerprint1.starts_with("RDX:"));
-    REQUIRE(fingerprint1.length() == 68);
-    REQUIRE(fingerprint1 == fingerprint2);
+      REQUIRE(fingerprint1.starts_with("RDX:"));
+      REQUIRE(fingerprint1.length() == 68);
+      REQUIRE(fingerprint1 == fingerprint2);
+    }
 
-    std::ignore = std::remove(
-      (std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_node_identity_fingerprint.db")
-        .string()
-        .c_str());
+    std::ignore = std::filesystem::remove(
+      std::filesystem::path(radix_relay::platform::get_temp_directory()) / "test_node_identity_fingerprint.db");
   }
 }

--- a/test/raw_signal_bridge_tests.cpp
+++ b/test/raw_signal_bridge_tests.cpp
@@ -1,0 +1,348 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "signal_bridge_cxx/lib.h"
+#include <radix_relay/platform/env_utils.hpp>
+
+TEST_CASE("SignalBridge Node Fingerprint Integration", "[signal][fingerprint][cxx]")
+{
+  SECTION("generate_node_fingerprint produces deterministic output using SignalBridge")
+  {
+    auto timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto db_path = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                    / ("test_signal_fingerprint_" + std::to_string(timestamp) + ".db"))
+                     .string();
+
+    {
+      auto bridge = radix_relay::new_signal_bridge(db_path.c_str());
+
+      auto identity = radix_relay::NodeIdentity{
+        .hostname = "testhost", .username = "testuser", .platform = "linux", .mac_address = "", .install_id = ""
+      };
+
+      auto fingerprint1 = radix_relay::generate_node_fingerprint(*bridge, identity);
+      auto fingerprint2 = radix_relay::generate_node_fingerprint(*bridge, identity);
+      auto fingerprint3 = radix_relay::generate_node_fingerprint(*bridge, identity);
+
+      REQUIRE(std::string(fingerprint1).starts_with("RDX:"));
+      REQUIRE(std::string(fingerprint1).length() == 68);
+      REQUIRE(std::string(fingerprint1) == std::string(fingerprint2));
+      REQUIRE(std::string(fingerprint2) == std::string(fingerprint3));
+    }
+
+    std::filesystem::remove(db_path);
+  }
+}
+
+
+TEST_CASE("SignalBridge Error Message Propagation", "[signal][error][cxx]")
+{
+  SECTION("Empty peer name produces specific error message")
+  {
+    auto timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto db_path = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                    / ("test_empty_peer_name_" + std::to_string(timestamp) + ".db"))
+                     .string();
+
+    {
+      auto bridge = radix_relay::new_signal_bridge(db_path.c_str());
+
+      REQUIRE_THROWS_WITH(
+        radix_relay::clear_peer_session(*bridge, ""), Catch::Matchers::ContainsSubstring("Specify a peer name"));
+    }
+
+    std::filesystem::remove(db_path);
+  }
+}
+
+TEST_CASE("SignalBridge CXX Integration", "[signal][cxx]")
+{
+  SECTION("SignalBridge constructor creates valid instance")
+  {
+    auto timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto db_path = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                    / ("test_signal_bridge_constructor_" + std::to_string(timestamp) + ".db"))
+                     .string();
+
+    {
+      REQUIRE_NOTHROW([&]() { auto bridge = radix_relay::new_signal_bridge(db_path.c_str()); }());
+    }
+
+    std::filesystem::remove(db_path);
+  }
+
+  SECTION("Alice and Bob can exchange encrypted messages")
+  {
+    auto timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                     / ("test_signal_alice_" + std::to_string(timestamp) + ".db"))
+                      .string();
+    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                   / ("test_signal_bob_" + std::to_string(timestamp) + ".db"))
+                    .string();
+
+    {
+      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
+      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
+
+      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
+      auto alice_bundle = radix_relay::generate_pre_key_bundle(*alice);
+      REQUIRE(!bob_bundle.empty());
+      REQUIRE(!alice_bundle.empty());
+
+      auto bob_rdx =
+        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "bob");
+      auto alice_rdx =
+        radix_relay::add_contact_and_establish_session(*bob, rust::Slice<const uint8_t>{ alice_bundle }, "alice");
+      REQUIRE(std::string(bob_rdx).starts_with("RDX:"));
+      REQUIRE(std::string(alice_rdx).starts_with("RDX:"));
+
+      std::string plaintext = "Hello Bob! This is Alice using SignalBridge from C++.";
+      std::vector<uint8_t> plaintext_bytes(plaintext.begin(), plaintext.end());
+
+      auto ciphertext =
+        radix_relay::encrypt_message(*alice, bob_rdx.c_str(), rust::Slice<const uint8_t>{ plaintext_bytes });
+      REQUIRE(!ciphertext.empty());
+      REQUIRE(ciphertext.size() > plaintext_bytes.size());
+
+      auto decrypted = radix_relay::decrypt_message(*bob, alice_rdx.c_str(), rust::Slice<const uint8_t>{ ciphertext });
+      REQUIRE(!decrypted.empty());
+      REQUIRE(decrypted.size() == plaintext_bytes.size());
+
+      std::string decrypted_string(decrypted.begin(), decrypted.end());
+      REQUIRE(decrypted_string == plaintext);
+    }
+
+    std::filesystem::remove(alice_db);
+    std::filesystem::remove(bob_db);
+  }
+
+  SECTION("Session management functions work correctly")
+  {
+    auto timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                     / ("test_signal_session_mgmt_alice_" + std::to_string(timestamp) + ".db"))
+                      .string();
+    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                   / ("test_signal_session_mgmt_bob_" + std::to_string(timestamp) + ".db"))
+                    .string();
+
+    {
+      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
+      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
+
+      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
+      auto bob_rdx =
+        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "bob");
+      REQUIRE(std::string(bob_rdx).starts_with("RDX:"));
+
+      REQUIRE_NOTHROW([&]() { radix_relay::clear_peer_session(*alice, bob_rdx.c_str()); }());
+
+      REQUIRE_NOTHROW([&]() { radix_relay::clear_all_sessions(*alice); }());
+
+      REQUIRE_NOTHROW([&]() { radix_relay::reset_identity(*alice); }());
+    }
+
+    std::filesystem::remove(alice_db);
+    std::filesystem::remove(bob_db);
+  }
+}
+
+TEST_CASE("SignalBridge Contact Management", "[signal][contacts][cxx]")
+{
+  SECTION("Can add contact from bundle and lookup by RDX")
+  {
+    auto timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                     / ("test_contact_alice_" + std::to_string(timestamp) + ".db"))
+                      .string();
+    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                   / ("test_contact_bob_" + std::to_string(timestamp) + ".db"))
+                    .string();
+
+    {
+      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
+      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
+
+      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
+      REQUIRE(!bob_bundle.empty());
+
+      auto bob_rdx =
+        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "");
+      REQUIRE(!bob_rdx.empty());
+      REQUIRE(std::string(bob_rdx).starts_with("RDX:"));
+
+      auto contact = radix_relay::lookup_contact(*alice, bob_rdx.c_str());
+      REQUIRE(std::string(contact.rdx_fingerprint) == std::string(bob_rdx));
+      REQUIRE(contact.user_alias.empty());
+      REQUIRE(contact.has_active_session);
+    }
+
+    std::filesystem::remove(alice_db);
+    std::filesystem::remove(bob_db);
+  }
+
+  SECTION("Can assign alias and lookup by alias")
+  {
+    auto timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                     / ("test_alias_alice_" + std::to_string(timestamp) + ".db"))
+                      .string();
+    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                   / ("test_alias_bob_" + std::to_string(timestamp) + ".db"))
+                    .string();
+
+    {
+      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
+      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
+
+      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
+      auto bob_rdx =
+        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "");
+
+      REQUIRE_NOTHROW([&]() { radix_relay::assign_contact_alias(*alice, bob_rdx.c_str(), "bob"); }());
+
+      auto contact_by_alias = radix_relay::lookup_contact(*alice, "bob");
+      REQUIRE(std::string(contact_by_alias.rdx_fingerprint) == std::string(bob_rdx));
+      REQUIRE(std::string(contact_by_alias.user_alias) == "bob");
+    }
+
+    std::filesystem::remove(alice_db);
+    std::filesystem::remove(bob_db);
+  }
+
+  SECTION("Can list all contacts")
+  {
+    auto timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                     / ("test_list_alice_" + std::to_string(timestamp) + ".db"))
+                      .string();
+    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                   / ("test_list_bob_" + std::to_string(timestamp) + ".db"))
+                    .string();
+    auto charlie_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                       / ("test_list_charlie_" + std::to_string(timestamp) + ".db"))
+                        .string();
+
+    {
+      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
+      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
+      auto charlie = radix_relay::new_signal_bridge(charlie_db.c_str());
+
+      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
+      auto charlie_bundle = radix_relay::generate_pre_key_bundle(*charlie);
+
+      auto bob_rdx =
+        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "bob");
+      auto charlie_rdx =
+        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ charlie_bundle }, "");
+
+      auto contacts = radix_relay::list_contacts(*alice);
+      REQUIRE(contacts.size() == 2);
+
+      bool found_bob = false;
+      bool found_charlie = false;
+
+      for (const auto &contact : contacts) {
+        if (std::string(contact.rdx_fingerprint) == std::string(bob_rdx)) {
+          found_bob = true;
+          REQUIRE(std::string(contact.user_alias) == "bob");
+        }
+        if (std::string(contact.rdx_fingerprint) == std::string(charlie_rdx)) {
+          found_charlie = true;
+          REQUIRE(contact.user_alias.empty());
+        }
+      }
+
+      REQUIRE(found_bob);
+      REQUIRE(found_charlie);
+    }
+
+    std::filesystem::remove(alice_db);
+    std::filesystem::remove(bob_db);
+    std::filesystem::remove(charlie_db);
+  }
+}
+
+TEST_CASE("SignalBridge Bundle Announcement", "[signal][bundle][nostr][cxx]")
+{
+  SECTION("Can generate prekey bundle announcement with RDX tag")
+  {
+    auto timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                     / ("test_bundle_announcement_" + std::to_string(timestamp) + ".db"))
+                      .string();
+
+    {
+      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
+
+      auto event_json = radix_relay::generate_prekey_bundle_announcement(*alice, "1.0.0-test");
+      REQUIRE(!event_json.empty());
+
+      // Parse JSON to verify structure
+      auto event_str = std::string(event_json);
+      REQUIRE(event_str.find("\"kind\":30078") != std::string::npos);
+      REQUIRE(event_str.find("\"rdx\"") != std::string::npos);
+      REQUIRE(event_str.find("RDX:") != std::string::npos);
+      REQUIRE(event_str.find("radix_version") != std::string::npos);
+      REQUIRE(event_str.find("1.0.0-test") != std::string::npos);
+      REQUIRE(event_str.find("radix_prekey_bundle_v1") != std::string::npos);
+      REQUIRE(event_str.find("\"content\":") != std::string::npos);
+    }
+
+    std::filesystem::remove(alice_db);
+  }
+
+  SECTION("Can add contact and establish session in one call")
+  {
+    auto timestamp =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                     / ("test_contact_session_alice_" + std::to_string(timestamp) + ".db"))
+                      .string();
+    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                   / ("test_contact_session_bob_" + std::to_string(timestamp) + ".db"))
+                    .string();
+
+    {
+      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
+      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
+
+      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
+
+      // Alice adds Bob as contact AND establishes session in one call
+      auto bob_rdx =
+        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "bob");
+      REQUIRE(std::string(bob_rdx).starts_with("RDX:"));
+
+      // Verify contact and session exist
+      auto contact = radix_relay::lookup_contact(*alice, bob_rdx.c_str());
+      REQUIRE(std::string(contact.user_alias) == "bob");
+      REQUIRE(contact.has_active_session);
+
+      // Verify Alice can encrypt to Bob
+      std::string plaintext = "Hello Bob!";
+      std::vector<uint8_t> plaintext_bytes(plaintext.begin(), plaintext.end());
+      auto ciphertext =
+        radix_relay::encrypt_message(*alice, bob_rdx.c_str(), rust::Slice<const uint8_t>{ plaintext_bytes });
+      REQUIRE(!ciphertext.empty());
+    }
+
+    std::filesystem::remove(alice_db);
+    std::filesystem::remove(bob_db);
+  }
+}

--- a/test/signal_bridge_tests.cpp
+++ b/test/signal_bridge_tests.cpp
@@ -1,347 +1,158 @@
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_string.hpp>
 #include <chrono>
 #include <filesystem>
-#include <memory>
-#include <string>
-#include <vector>
-
-#include "signal_bridge_cxx/lib.h"
+#include <nlohmann/json.hpp>
 #include <radix_relay/platform/env_utils.hpp>
+#include <radix_relay/signal_bridge.hpp>
 
-TEST_CASE("SignalBridge Node Fingerprint Integration", "[signal][fingerprint][cxx]")
+TEST_CASE("signal::bridge basic functionality", "[signal][wrapper]")
 {
-  SECTION("generate_node_fingerprint produces deterministic output using SignalBridge")
+  auto timestamp =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  auto db_path = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                  / ("test_wrapper_" + std::to_string(timestamp) + ".db"))
+                   .string();
+
+  SECTION("Wrapper can be constructed from db path")
   {
-    auto timestamp =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    auto db_path = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                    / ("test_signal_fingerprint_" + std::to_string(timestamp) + ".db"))
-                     .string();
-
     {
-      auto bridge = radix_relay::new_signal_bridge(db_path.c_str());
+      auto wrapper = radix_relay::signal::bridge(db_path);
+      auto fingerprint = wrapper.get_node_fingerprint();
 
-      auto identity = radix_relay::NodeIdentity{
-        .hostname = "testhost", .username = "testuser", .platform = "linux", .mac_address = "", .install_id = ""
-      };
-
-      auto fingerprint1 = radix_relay::generate_node_fingerprint(*bridge, identity);
-      auto fingerprint2 = radix_relay::generate_node_fingerprint(*bridge, identity);
-      auto fingerprint3 = radix_relay::generate_node_fingerprint(*bridge, identity);
-
-      REQUIRE(std::string(fingerprint1).starts_with("RDX:"));
-      REQUIRE(std::string(fingerprint1).length() == 68);
-      REQUIRE(std::string(fingerprint1) == std::string(fingerprint2));
-      REQUIRE(std::string(fingerprint2) == std::string(fingerprint3));
+      REQUIRE(fingerprint.starts_with("RDX:"));
+      REQUIRE(fingerprint.length() == 68);
     }
+    std::filesystem::remove(db_path);
+  }
 
+  SECTION("Wrapper can be constructed from shared_ptr with db path")
+  {
+    {
+      auto wrapper = std::make_shared<radix_relay::signal::bridge>(db_path);
+      auto fingerprint = wrapper->get_node_fingerprint();
+
+      REQUIRE(fingerprint.starts_with("RDX:"));
+      REQUIRE(fingerprint.length() == 68);
+    }
     std::filesystem::remove(db_path);
   }
 }
 
-
-TEST_CASE("SignalBridge Error Message Propagation", "[signal][error][cxx]")
+TEST_CASE("signal::bridge contact management", "[signal][wrapper][contacts]")
 {
-  SECTION("Empty peer name produces specific error message")
-  {
-    auto timestamp =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    auto db_path = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                    / ("test_empty_peer_name_" + std::to_string(timestamp) + ".db"))
-                     .string();
-
-    {
-      auto bridge = radix_relay::new_signal_bridge(db_path.c_str());
-
-      REQUIRE_THROWS_WITH(
-        radix_relay::clear_peer_session(*bridge, ""), Catch::Matchers::ContainsSubstring("Specify a peer name"));
-    }
-
-    std::filesystem::remove(db_path);
-  }
-}
-
-TEST_CASE("SignalBridge CXX Integration", "[signal][cxx]")
-{
-  SECTION("SignalBridge constructor creates valid instance")
-  {
-    auto timestamp =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    auto db_path = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                    / ("test_signal_bridge_constructor_" + std::to_string(timestamp) + ".db"))
-                     .string();
-
-    {
-      REQUIRE_NOTHROW([&]() { auto bridge = radix_relay::new_signal_bridge(db_path.c_str()); }());
-    }
-
-    std::filesystem::remove(db_path);
-  }
-
-  SECTION("Alice and Bob can exchange encrypted messages")
-  {
-    auto timestamp =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                     / ("test_signal_alice_" + std::to_string(timestamp) + ".db"))
-                      .string();
-    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                   / ("test_signal_bob_" + std::to_string(timestamp) + ".db"))
+  auto timestamp =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                   / ("test_wrapper_alice_" + std::to_string(timestamp) + ".db"))
                     .string();
+  auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                 / ("test_wrapper_bob_" + std::to_string(timestamp) + ".db"))
+                  .string();
 
+  SECTION("list_contacts returns empty for fresh identity")
+  {
     {
-      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
-      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
+      auto wrapper = radix_relay::signal::bridge(alice_db);
+      auto contacts = wrapper.list_contacts();
 
-      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
-      auto alice_bundle = radix_relay::generate_pre_key_bundle(*alice);
-      REQUIRE(!bob_bundle.empty());
-      REQUIRE(!alice_bundle.empty());
-
-      auto bob_rdx =
-        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "bob");
-      auto alice_rdx =
-        radix_relay::add_contact_and_establish_session(*bob, rust::Slice<const uint8_t>{ alice_bundle }, "alice");
-      REQUIRE(std::string(bob_rdx).starts_with("RDX:"));
-      REQUIRE(std::string(alice_rdx).starts_with("RDX:"));
-
-      std::string plaintext = "Hello Bob! This is Alice using SignalBridge from C++.";
-      std::vector<uint8_t> plaintext_bytes(plaintext.begin(), plaintext.end());
-
-      auto ciphertext =
-        radix_relay::encrypt_message(*alice, bob_rdx.c_str(), rust::Slice<const uint8_t>{ plaintext_bytes });
-      REQUIRE(!ciphertext.empty());
-      REQUIRE(ciphertext.size() > plaintext_bytes.size());
-
-      auto decrypted = radix_relay::decrypt_message(*bob, alice_rdx.c_str(), rust::Slice<const uint8_t>{ ciphertext });
-      REQUIRE(!decrypted.empty());
-      REQUIRE(decrypted.size() == plaintext_bytes.size());
-
-      std::string decrypted_string(decrypted.begin(), decrypted.end());
-      REQUIRE(decrypted_string == plaintext);
+      REQUIRE(contacts.empty());
     }
-
     std::filesystem::remove(alice_db);
-    std::filesystem::remove(bob_db);
   }
 
-  SECTION("Session management functions work correctly")
+  SECTION("Session establishment and contact listing")
   {
-    auto timestamp =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                     / ("test_signal_session_mgmt_alice_" + std::to_string(timestamp) + ".db"))
-                      .string();
-    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                   / ("test_signal_session_mgmt_bob_" + std::to_string(timestamp) + ".db"))
-                    .string();
-
     {
-      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
-      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
+      auto alice = std::make_shared<radix_relay::signal::bridge>(alice_db);
+      auto bob = std::make_shared<radix_relay::signal::bridge>(bob_db);
 
-      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
-      auto bob_rdx =
-        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "bob");
-      REQUIRE(std::string(bob_rdx).starts_with("RDX:"));
+      auto bob_bundle = bob->generate_prekey_bundle_announcement("test-0.1.0");
+      auto bob_bundle_json = nlohmann::json::parse(bob_bundle);
+      auto bob_bundle_base64 = bob_bundle_json["content"].template get<std::string>();
 
-      REQUIRE_NOTHROW([&]() { radix_relay::clear_peer_session(*alice, bob_rdx.c_str()); }());
+      auto bob_rdx = alice->add_contact_and_establish_session_from_base64(bob_bundle_base64, "bob");
 
-      REQUIRE_NOTHROW([&]() { radix_relay::clear_all_sessions(*alice); }());
-
-      REQUIRE_NOTHROW([&]() { radix_relay::reset_identity(*alice); }());
+      auto contacts = alice->list_contacts();
+      REQUIRE(contacts.size() == 1);
+      REQUIRE(contacts[0].rdx_fingerprint == bob_rdx);
+      REQUIRE(contacts[0].user_alias == "bob");
+      REQUIRE(contacts[0].has_active_session);
     }
-
     std::filesystem::remove(alice_db);
     std::filesystem::remove(bob_db);
   }
 }
 
-TEST_CASE("SignalBridge Contact Management", "[signal][contacts][cxx]")
+TEST_CASE("signal::bridge encryption/decryption", "[signal][wrapper][encryption]")
 {
-  SECTION("Can add contact from bundle and lookup by RDX")
-  {
-    auto timestamp =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                     / ("test_contact_alice_" + std::to_string(timestamp) + ".db"))
-                      .string();
-    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                   / ("test_contact_bob_" + std::to_string(timestamp) + ".db"))
+  auto timestamp =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                   / ("test_wrapper_encrypt_alice_" + std::to_string(timestamp) + ".db"))
                     .string();
+  auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                 / ("test_wrapper_encrypt_bob_" + std::to_string(timestamp) + ".db"))
+                  .string();
 
+  SECTION("Encrypt and decrypt message through wrapper")
+  {
     {
-      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
-      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
+      auto alice = std::make_shared<radix_relay::signal::bridge>(alice_db);
+      auto bob = std::make_shared<radix_relay::signal::bridge>(bob_db);
 
-      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
-      REQUIRE(!bob_bundle.empty());
+      auto bob_bundle = bob->generate_prekey_bundle_announcement("test-0.1.0");
+      auto bob_bundle_json = nlohmann::json::parse(bob_bundle);
+      auto bob_bundle_base64 = bob_bundle_json["content"].template get<std::string>();
+      auto bob_rdx = alice->add_contact_and_establish_session_from_base64(bob_bundle_base64, "");
 
-      auto bob_rdx =
-        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "");
-      REQUIRE(!bob_rdx.empty());
-      REQUIRE(std::string(bob_rdx).starts_with("RDX:"));
+      auto alice_bundle = alice->generate_prekey_bundle_announcement("test-0.1.0");
+      auto alice_bundle_json = nlohmann::json::parse(alice_bundle);
+      auto alice_bundle_base64 = alice_bundle_json["content"].template get<std::string>();
+      auto alice_rdx = bob->add_contact_and_establish_session_from_base64(alice_bundle_base64, "");
 
-      auto contact = radix_relay::lookup_contact(*alice, bob_rdx.c_str());
-      REQUIRE(std::string(contact.rdx_fingerprint) == std::string(bob_rdx));
-      REQUIRE(contact.user_alias.empty());
-      REQUIRE(contact.has_active_session);
+      const std::string plaintext = "Hello Bob!";
+      const std::vector<uint8_t> message_bytes(plaintext.begin(), plaintext.end());
+
+      auto encrypted = alice->encrypt_message(bob_rdx, message_bytes);
+      auto decrypted = bob->decrypt_message(alice_rdx, encrypted);
+
+      std::string decrypted_str(decrypted.begin(), decrypted.end());
+      REQUIRE(decrypted_str == plaintext);
     }
-
     std::filesystem::remove(alice_db);
     std::filesystem::remove(bob_db);
-  }
-
-  SECTION("Can assign alias and lookup by alias")
-  {
-    auto timestamp =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                     / ("test_alias_alice_" + std::to_string(timestamp) + ".db"))
-                      .string();
-    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                   / ("test_alias_bob_" + std::to_string(timestamp) + ".db"))
-                    .string();
-
-    {
-      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
-      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
-
-      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
-      auto bob_rdx =
-        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "");
-
-      REQUIRE_NOTHROW([&]() { radix_relay::assign_contact_alias(*alice, bob_rdx.c_str(), "bob"); }());
-
-      auto contact_by_alias = radix_relay::lookup_contact(*alice, "bob");
-      REQUIRE(std::string(contact_by_alias.rdx_fingerprint) == std::string(bob_rdx));
-      REQUIRE(std::string(contact_by_alias.user_alias) == "bob");
-    }
-
-    std::filesystem::remove(alice_db);
-    std::filesystem::remove(bob_db);
-  }
-
-  SECTION("Can list all contacts")
-  {
-    auto timestamp =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                     / ("test_list_alice_" + std::to_string(timestamp) + ".db"))
-                      .string();
-    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                   / ("test_list_bob_" + std::to_string(timestamp) + ".db"))
-                    .string();
-    auto charlie_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                       / ("test_list_charlie_" + std::to_string(timestamp) + ".db"))
-                        .string();
-
-    {
-      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
-      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
-      auto charlie = radix_relay::new_signal_bridge(charlie_db.c_str());
-
-      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
-      auto charlie_bundle = radix_relay::generate_pre_key_bundle(*charlie);
-
-      auto bob_rdx =
-        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "bob");
-      auto charlie_rdx =
-        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ charlie_bundle }, "");
-
-      auto contacts = radix_relay::list_contacts(*alice);
-      REQUIRE(contacts.size() == 2);
-
-      bool found_bob = false;
-      bool found_charlie = false;
-
-      for (const auto &contact : contacts) {
-        if (std::string(contact.rdx_fingerprint) == std::string(bob_rdx)) {
-          found_bob = true;
-          REQUIRE(std::string(contact.user_alias) == "bob");
-        }
-        if (std::string(contact.rdx_fingerprint) == std::string(charlie_rdx)) {
-          found_charlie = true;
-          REQUIRE(contact.user_alias.empty());
-        }
-      }
-
-      REQUIRE(found_bob);
-      REQUIRE(found_charlie);
-    }
-
-    std::filesystem::remove(alice_db);
-    std::filesystem::remove(bob_db);
-    std::filesystem::remove(charlie_db);
   }
 }
 
-TEST_CASE("SignalBridge Bundle Announcement", "[signal][bundle][nostr][cxx]")
+TEST_CASE("signal::bridge alias management", "[signal][wrapper][alias]")
 {
-  SECTION("Can generate prekey bundle announcement with RDX tag")
-  {
-    auto timestamp =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                     / ("test_bundle_announcement_" + std::to_string(timestamp) + ".db"))
-                      .string();
-
-    {
-      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
-
-      auto event_json = radix_relay::generate_prekey_bundle_announcement(*alice, "1.0.0-test");
-      REQUIRE(!event_json.empty());
-
-      // Parse JSON to verify structure
-      auto event_str = std::string(event_json);
-      REQUIRE(event_str.find("\"kind\":30078") != std::string::npos);
-      REQUIRE(event_str.find("\"rdx\"") != std::string::npos);
-      REQUIRE(event_str.find("RDX:") != std::string::npos);
-      REQUIRE(event_str.find("radix_version") != std::string::npos);
-      REQUIRE(event_str.find("1.0.0-test") != std::string::npos);
-      REQUIRE(event_str.find("radix_prekey_bundle_v1") != std::string::npos);
-      REQUIRE(event_str.find("\"content\":") != std::string::npos);
-    }
-
-    std::filesystem::remove(alice_db);
-  }
-
-  SECTION("Can add contact and establish session in one call")
-  {
-    auto timestamp =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                     / ("test_contact_session_alice_" + std::to_string(timestamp) + ".db"))
-                      .string();
-    auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
-                   / ("test_contact_session_bob_" + std::to_string(timestamp) + ".db"))
+  auto timestamp =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  auto alice_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                   / ("test_wrapper_alias_alice_" + std::to_string(timestamp) + ".db"))
                     .string();
+  auto bob_db = (std::filesystem::path(radix_relay::platform::get_temp_directory())
+                 / ("test_wrapper_alias_bob_" + std::to_string(timestamp) + ".db"))
+                  .string();
 
+  SECTION("Assign and lookup contact alias")
+  {
     {
-      auto alice = radix_relay::new_signal_bridge(alice_db.c_str());
-      auto bob = radix_relay::new_signal_bridge(bob_db.c_str());
+      auto alice = std::make_shared<radix_relay::signal::bridge>(alice_db);
+      auto bob = std::make_shared<radix_relay::signal::bridge>(bob_db);
 
-      auto bob_bundle = radix_relay::generate_pre_key_bundle(*bob);
+      auto bob_bundle = bob->generate_prekey_bundle_announcement("test-0.1.0");
+      auto bob_bundle_json = nlohmann::json::parse(bob_bundle);
+      auto bob_bundle_base64 = bob_bundle_json["content"].template get<std::string>();
+      auto bob_rdx = alice->add_contact_and_establish_session_from_base64(bob_bundle_base64, "");
 
-      // Alice adds Bob as contact AND establishes session in one call
-      auto bob_rdx =
-        radix_relay::add_contact_and_establish_session(*alice, rust::Slice<const uint8_t>{ bob_bundle }, "bob");
-      REQUIRE(std::string(bob_rdx).starts_with("RDX:"));
+      const std::string alias = "BobTheBuilder";
+      alice->assign_contact_alias(bob_rdx, alias);
 
-      // Verify contact and session exist
-      auto contact = radix_relay::lookup_contact(*alice, bob_rdx.c_str());
-      REQUIRE(std::string(contact.user_alias) == "bob");
-      REQUIRE(contact.has_active_session);
-
-      // Verify Alice can encrypt to Bob
-      std::string plaintext = "Hello Bob!";
-      std::vector<uint8_t> plaintext_bytes(plaintext.begin(), plaintext.end());
-      auto ciphertext =
-        radix_relay::encrypt_message(*alice, bob_rdx.c_str(), rust::Slice<const uint8_t>{ plaintext_bytes });
-      REQUIRE(!ciphertext.empty());
+      auto contact = alice->lookup_contact(alias);
+      REQUIRE(contact.rdx_fingerprint == bob_rdx);
+      REQUIRE(contact.user_alias == alias);
     }
-
     std::filesystem::remove(alice_db);
     std::filesystem::remove(bob_db);
   }

--- a/test/test_doubles/test_double_signal_bridge.hpp
+++ b/test/test_doubles/test_double_signal_bridge.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <radix_relay/concepts/signal_bridge.hpp>
+#include <radix_relay/signal_types.hpp>
+#include <string>
+#include <vector>
+
+namespace radix_relay_test {
+
+struct TestDoubleSignalBridge
+{
+  mutable std::vector<std::string> called_methods;
+  std::string fingerprint_to_return = "RDX:test_fingerprint";
+  std::vector<radix_relay::signal::contact_info> contacts_to_return;
+
+  auto get_node_fingerprint() -> std::string
+  {
+    called_methods.push_back("get_node_fingerprint");
+    return fingerprint_to_return;
+  }
+
+  auto list_contacts() -> std::vector<radix_relay::signal::contact_info>
+  {
+    called_methods.push_back("list_contacts");
+    return contacts_to_return;
+  }
+
+  auto was_called(const std::string &method) const -> bool
+  {
+    return std::find(called_methods.begin(), called_methods.end(), method) != called_methods.end();
+  }
+
+  auto call_count(const std::string &method) const -> size_t
+  {
+    return static_cast<size_t>(std::count(called_methods.begin(), called_methods.end(), method));
+  }
+
+  auto clear_calls() -> void { called_methods.clear(); }
+
+  auto encrypt_message(const std::string & /*rdx*/, const std::vector<uint8_t> &bytes) -> std::vector<uint8_t>
+  {
+    called_methods.push_back("encrypt_message");
+    return bytes;
+  }
+
+  auto decrypt_message(const std::string & /*rdx*/, const std::vector<uint8_t> &bytes) -> std::vector<uint8_t>
+  {
+    called_methods.push_back("decrypt_message");
+    return bytes;
+  }
+
+  auto add_contact_and_establish_session_from_base64(const std::string & /*bundle*/, const std::string & /*alias*/)
+    -> std::string
+  {
+    called_methods.push_back("add_contact_and_establish_session_from_base64");
+    return "RDX:new_contact";
+  }
+
+  auto generate_prekey_bundle_announcement(const std::string & /*version*/) -> std::string
+  {
+    called_methods.push_back("generate_prekey_bundle_announcement");
+    return "{}";
+  }
+
+  auto assign_contact_alias(const std::string & /*rdx*/, const std::string & /*alias*/) -> void
+  {
+    called_methods.push_back("assign_contact_alias");
+  }
+
+  auto lookup_contact(const std::string & /*alias*/) -> radix_relay::signal::contact_info
+  {
+    called_methods.push_back("lookup_contact");
+    return radix_relay::signal::contact_info{
+      .rdx_fingerprint = "RDX:test_contact",
+      .nostr_pubkey = "npub_test",
+      .user_alias = "test_alias",
+      .has_active_session = true,
+    };
+  }
+
+  auto create_and_sign_encrypted_message(const std::string & /*rdx*/,
+    const std::string & /*content*/,
+    uint32_t /*timestamp*/,
+    const std::string & /*version*/) -> std::string
+  {
+    called_methods.push_back("create_and_sign_encrypted_message");
+    return "{}";
+  }
+
+  auto sign_nostr_event(const std::string & /*event_json*/) -> std::string
+  {
+    called_methods.push_back("sign_nostr_event");
+    return "{}";
+  }
+};
+
+static_assert(radix_relay::concepts::signal_bridge<TestDoubleSignalBridge>);
+
+}// namespace radix_relay_test


### PR DESCRIPTION
- add C++ friendly wrapper for SignalBridge
- use shared_ptr to wrapper where bridge is needed